### PR TITLE
fix url param satisfaction in sync with selection

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import { useEffect, useState } from "react";
-import { useSearchParams } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import confetti from "canvas-confetti";
 import { usePostHog } from "posthog-js/react";
 import { env } from "~/env";
@@ -8,6 +8,8 @@ import { env } from "~/env";
 export default function Home() {
   const searchParams = useSearchParams()
   const satisfactionParam = searchParams.get('satisfaction')
+  const pathname = usePathname()
+  const router = useRouter()
   const [satisfaction, setSatisfaction] = useState<number>(-1)
   const [feedback, setFeedback] = useState('')
   const [submitted, setSubmitted] = useState<boolean>(false)
@@ -38,6 +40,16 @@ export default function Home() {
   useEffect(() => {
     setSatisfaction(parseInt(satisfactionParam ?? '-1'))
   }, [satisfactionParam])
+
+  useEffect(() => {
+    if (satisfaction !== -1) {
+      const current = new URLSearchParams(Array.from(searchParams.entries()))
+      current.set('satisfaction', satisfaction.toString())
+      router.replace(`${pathname}?${current.toString()}`, {
+        scroll: false,
+      })
+    }
+  }, [satisfaction])
 
   return (
     <>


### PR DESCRIPTION
thank you [icyjoseph](https://github.com/vercel/next.js/discussions/47583#discussioncomment-5449707)

may want to think about tests in a future PR, but for now going with the flow (at least that i could see) and no tests

would typically take screen caps before + after but i'm on a time crunch! may return to make those closer to the end of the day

further thoughts:
- perhaps a constant for the `-1` value
- do i want to care about this: 
    - <img width="920" alt="image" src="https://github.com/PostHog/posthog-csat/assets/6620744/9ab50a08-8b5d-49cb-99e9-cff7a1a04a4e">